### PR TITLE
[v0.2.2] Fixed previous and next API endpoints

### DIFF
--- a/lib/spotify/sdk/connect/device.rb
+++ b/lib/spotify/sdk/connect/device.rb
@@ -144,7 +144,7 @@ module Spotify
 
         ##
         # Skip to previous track on device.
-        # PUT /v1/me/player/previous
+        # POST /v1/me/player/previous
         #
         # @example
         #   device = @sdk.connect.devices[0]
@@ -155,13 +155,13 @@ module Spotify
         # @return [Spotify::SDK::Connect::Device] self Return itself, so chained methods can be supported.
         #
         def previous!
-          parent.send_http_request(:put, "/v1/me/player/previous?device_id=%s" % id, http_options: {expect_nil: true})
+          parent.send_http_request(:post, "/v1/me/player/previous?device_id=%s" % id, http_options: {expect_nil: true})
           self
         end
 
         ##
         # Skip to next track on device.
-        # PUT /v1/me/player/next
+        # POST /v1/me/player/next
         #
         # @example
         #   device = @sdk.connect.devices[0]
@@ -172,7 +172,7 @@ module Spotify
         # @return [Spotify::SDK::Connect::Device] self Return itself, so chained methods can be supported.
         #
         def next!
-          parent.send_http_request(:put, "/v1/me/player/next?device_id=%s" % id, http_options: {expect_nil: true})
+          parent.send_http_request(:post, "/v1/me/player/next?device_id=%s" % id, http_options: {expect_nil: true})
           self
         end
 

--- a/spec/lib/spotify/sdk/connect/device_spec.rb
+++ b/spec/lib/spotify/sdk/connect/device_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Spotify::SDK::Connect::Device do
 
   describe "#previous!" do
     it "should make an api call" do
-      stub = stub_request(:put, "https://api.spotify.com/v1/me/player/previous?device_id=#{raw_data[:id]}")
+      stub = stub_request(:post, "https://api.spotify.com/v1/me/player/previous?device_id=#{raw_data[:id]}")
              .with(headers: {Authorization: "Bearer access_token"})
 
       subject.previous!
@@ -124,7 +124,7 @@ RSpec.describe Spotify::SDK::Connect::Device do
 
   describe "#next!" do
     it "should make an api call" do
-      stub = stub_request(:put, "https://api.spotify.com/v1/me/player/next?device_id=#{raw_data[:id]}")
+      stub = stub_request(:post, "https://api.spotify.com/v1/me/player/next?device_id=#{raw_data[:id]}")
              .with(headers: {Authorization: "Bearer access_token"})
 
       subject.next!


### PR DESCRIPTION
Fixed: `Spotify::SDK::Connect::Device` methods `next!` and `previous!` now send POST requests